### PR TITLE
chore: rename org from Wuji-Technology-Co-Ltd to wuji-technology

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "example/utils/mujoco-sim"]
 	path = example/utils/mujoco-sim
-	url = https://github.com/Wuji-Technology-Co-Ltd/mujoco-sim
+	url = https://github.com/wuji-technology/mujoco-sim
 [submodule "wuji_retargeting/wuji_hand_description"]
 	path = wuji_retargeting/wuji_hand_description
-	url = https://github.com/Wuji-Technology-Co-Ltd/wuji_hand_description
+	url = https://github.com/wuji-technology/wuji_hand_description

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ If you find this project useful, please consider citing:
   title={WujiHand Retargeting},
   author={Guanqi He and Wentao Zhang},
   year={2025},
-  url={https://github.com/Wuji-Technology-Co-Ltd/wuji_retargeting},
+  url={https://github.com/wuji-technology/wuji_retargeting},
   note={* Equal contribution}
 }
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -237,7 +237,7 @@ wuji_retargeting/
   title={WujiHand Retargeting},
   author={Guanqi He and Wentao Zhang},
   year={2025},
-  url={https://github.com/Wuji-Technology-Co-Ltd/wuji_retargeting},
+  url={https://github.com/wuji-technology/wuji_retargeting},
   note={* Equal contribution}
 }
 ```


### PR DESCRIPTION
将所有 GitHub 组织名引用从 `Wuji-Technology-Co-Ltd` 更新为 `wuji-technology`。