### PR TITLE
fix: correct mjcf and urdf path resolution

### DIFF
--- a/example/teleop_sim.py
+++ b/example/teleop_sim.py
@@ -159,8 +159,8 @@ def run_teleop(
 
     # Load MuJoCo model
     mjcf_path = (
-        Path(__file__).resolve().parents[1]
-        / "wuji_retargeting" / "wuji-description" / "hand" / "body" / "mjcf" / f"{hand_side}.xml"
+        Path(__file__).resolve().parent
+        / "utils" / "mujoco-sim" / "wuji_hand_description" / "mjcf" / f"{hand_side}.xml"
     )
     if not mjcf_path.exists():
         raise FileNotFoundError(f"MuJoCo model file not found: {mjcf_path}")

--- a/example/viz/tuning_viewer.py
+++ b/example/viz/tuning_viewer.py
@@ -122,11 +122,9 @@ class TuningViewer:
 
         # Load MuJoCo model
         if mujoco_model_dir is None:
-            # Default for configs without explicit mjcf_path: use the
-            # wuji-description submodule shipped inside the retargeting package.
             mujoco_model_dir = (
-                Path(__file__).resolve().parents[2]
-                / "wuji_retargeting" / "wuji-description" / "hand" / "body"
+                Path(__file__).resolve().parents[1]
+                / "utils" / "mujoco-sim" / "wuji_hand_description"
             )
         mjcf_path = Path(mujoco_model_dir) / "mjcf" / f"{self.hand_side}.xml"
         if not mjcf_path.exists():

--- a/wuji_retargeting/opt/base.py
+++ b/wuji_retargeting/opt/base.py
@@ -192,7 +192,7 @@ class BaseOptimizer(ABC):
         self.norm_delta = retarget_config.get('norm_delta', 0.04)
 
         # Load URDF
-        urdf_path = str((_PACKAGE_ROOT / f"wuji-description/hand/body/urdf/{self.hand_side}.urdf").resolve())
+        urdf_path = str((_PACKAGE_ROOT / f"example/utils/mujoco-sim/wuji_hand_description/urdf/{self.hand_side}.urdf").resolve())
         self.robot = RobotWrapper(urdf_path, hand_side=self.hand_side)
         self.num_joints = self.robot.model.nq
 

--- a/wuji_retargeting/viz/tuning_viewer.py
+++ b/wuji_retargeting/viz/tuning_viewer.py
@@ -122,8 +122,8 @@ class TuningViewer:
         # Load MuJoCo model
         if mujoco_model_dir is None:
             mujoco_model_dir = (
-                Path(__file__).resolve().parents[1]
-                / "wuji-description" / "hand" / "body"
+                Path(__file__).resolve().parents[2]
+                / "example" / "utils" / "mujoco-sim" / "wuji_hand_description"
             )
         mjcf_path = Path(mujoco_model_dir) / "mjcf" / f"{self.hand_side}.xml"
         if not mjcf_path.exists():


### PR DESCRIPTION
Fix hardcoded `wuji-description` paths to use the actual submodule location

The `wuji-description` directory does not exist in the repository. The hand description assets (URDF and MJCF) are provided via the wuji_hand_description submodule. Updated all hardcoded paths accordingly:

- teleop_sim.py: fix MJCF path for MuJoCo model loading
- base.py: fix URDF path for robot model loading
- tuning_viewer.py: fix default MJCF model directory
- tuning_viewer.py: fix default MJCF model directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 优化项目目录结构，更新了机械手模型文件的加载路径引用，以适应新的文件组织方式。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->